### PR TITLE
Revert librosa version to 0.9.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 soundfile
-librosa
+librosa==0.9.2
 configparser
 pandas
 torch


### PR DESCRIPTION
Revert librosa version, otherwise it will report error `TypeError: resample() takes 1 positional argument but 3 were given`:
```
$ python noisyspeech_synthesizer.py -root ./
Number of files to be synthesized: 60000
Start idx: 0
Stop idx: 59999
Generating synthesized data in ./
Traceback (most recent call last):
  File "noisyspeech_synthesizer.py", line 216, in <module>
    noise_source_files, noise_clipped_files, noise_low_activity_files = synthesize(params)
  File "noisyspeech_synthesizer.py", line 96, in synthesize
    gen_audio(is_clean=True, params=params, index=clean_index)
  File "/home/intel/yuan/workspace/ai/intel_dns/IntelNeuromorphicDNSChallenge-zxy/microsoft_dns/noisyspeech_synthesizer_singleprocess.py", line 136, in gen_audio
    build_audio(is_clean, params, index, audio_samples_length)
  File "/home/intel/yuan/workspace/ai/intel_dns/IntelNeuromorphicDNSChallenge-zxy/microsoft_dns/noisyspeech_synthesizer_singleprocess.py", line 88, in build_audio
    input_audio = librosa.resample(input_audio, fs_input, fs_output)
TypeError: resample() takes 1 positional argument but 3 were given
```